### PR TITLE
Fix components to work with Gecko SDK 4.4.5

### DIFF
--- a/component/Silabs/rz_button.slcc
+++ b/component/Silabs/rz_button.slcc
@@ -24,12 +24,6 @@ template_contribution:
   - name: component_catalog
     value: rz_button_press
 
-  - name: event_handler
-    value:
-      event: service_init
-      include: "rz_button.h"
-      handler: "rz_button_init"
-
 include:
   - path: rz_button
     file_list:

--- a/src/Zigbee/power_configuration_server/power_configuration_server.h
+++ b/src/Zigbee/power_configuration_server/power_configuration_server.h
@@ -83,4 +83,9 @@ void emberAfPowerConfigurationClusterBatteryUpdated(uint8_t endpoint,
 /** @} */ // end of name Callbacks
 /** @} */ // end of power-configuration-server
 
+/**
+ * @brief Called after the Power Configuration cluster is initialized.
+ */
+void emberAfPowerConfigurationClusterServerInitCallback(uint8_t endpoint);
+
 #endif // ZIGBEE_POWER_CONFIGURATION_SERVER_H


### PR DESCRIPTION
For some reason can no longer use `sl_service_init()` for event initialization. So now initialization should be called from the `emberAfMainInitCallback()`

This affects:
- rz_button_press
- power_configuration_server
- rz_led_blink (fixed in earlier PRs)