### PR TITLE
Update mgm210_custom_board configuration

### DIFF
--- a/hardware/board/config/brd_mgm210_expansion/sl_iostream_usart_vcom_config.h
+++ b/hardware/board/config/brd_mgm210_expansion/sl_iostream_usart_vcom_config.h
@@ -92,7 +92,7 @@
 #define SL_IOSTREAM_USART_VCOM_TX_PIN            0
 
 // USART0 RX on PA1
-#define SL_IOSTREAM_USART_VCOM_RX_PORT           gpioPortA
+#define SL_IOSTREAM_USART_VCOM_RX_PORT           gpioPortC
 #define SL_IOSTREAM_USART_VCOM_RX_PIN            4
 
 // [USART_SL_IOSTREAM_USART_VCOM]$

--- a/hardware/board/config/brd_mgm210_expansion/sl_simple_button_btn0_config.h
+++ b/hardware/board/config/brd_mgm210_expansion/sl_simple_button_btn0_config.h
@@ -48,7 +48,7 @@
 
 // <gpio> SL_SIMPLE_BUTTON_BTN0
 // $[GPIO_SL_SIMPLE_BUTTON_BTN0]
-#define SL_SIMPLE_BUTTON_BTN0_PORT               gpioPortC
+#define SL_SIMPLE_BUTTON_BTN0_PORT               gpioPortA
 #define SL_SIMPLE_BUTTON_BTN0_PIN                4
 
 // [GPIO_SL_SIMPLE_BUTTON_BTN0]$


### PR DESCRIPTION
Changes to make the `brd_mgm210_expansion` compatible with version 2.x and newer of the hardware https://github.com/Adminiuga/MGM210-Expansion/releases/tag/v2.0.0

Button uses `PA4` pin now, since this pin can wakeup from EM2. UART_RX was updates to `PC4`, in other words swap pins PA4 and PC4 as in UART_RX and BTN0 pin.
